### PR TITLE
Add job-dispatch mechanism for flexible data ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `data/` folder must include:
 
 - a base valid NWB file to append the ephys data to
 - the raw data
-- (optional) a list of json files produced by the [aind-ephys-job-dispatch]() process
+- (optional) a list of json files produced by the [aind-ephys-job-dispatch](https://github.com/AllenNeuralDynamics/aind-ephys-job-dispatch/) process
 
 If no JSON files are provided, the capsule will assume the raw data is in the [AIND
 ephys format](https://github.com/AllenNeuralDynamics/aind-physio-arch/blob/main/doc/file_formats/ephys.md). When JSON files are provided, the capsule will use this information 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ The `code/run` script takes the following arguments:
                         Duration of stub recording
   --skip-lfp            Whether to write LFP electrical series
   --write-raw           Whether to write RAW electrical series
-  --write-nidq          Whether to write NIDQ stream
   --lfp_temporal_factor LFP_TEMPORAL_FACTOR
                         Ratio of input samples to output samples in time. Use 0 or 1 to keep all samples. Default is 2.
   --lfp_spatial_factor LFP_SPATIAL_FACTOR

--- a/README.md
+++ b/README.md
@@ -4,47 +4,43 @@
 
 ### Description
 
-This capsule is designed to append device, electrodes, and electrical series (raw and LFP) information to an existing NWB file.
+This capsule is designed to append device, electrodes, LFP and raw (optional) electrical series information to an existing NWB file.
 
 
 ### Inputs
 
-The `data/` folder must include the session dataset and optionally the following JSON files:
+The `data/` folder must include:
 
-- `subject.json`: Subject information following the [aind-data-schema]() specification
-- `data_description.json`: session information following the [aind-data-schema]() specification
+- a base valid NWB file to append the ephys data to
+- the raw data
+- (optional) a list of json files produced by the [aind-ephys-job-dispatch]() process
 
-The `data_description.json` is only used to access the `name` field, which is used as session name.
-An minimal example `data_description.json` file:
-
-```json
-{
-    "name": "my-awesome-session-name"
-}
-```
-
-If these files are missing, a mock NWB file is created.
-
-If the `data/` folder includes an NWB file, this is copied to the results folder.
-
+If no JSON files are provided, the capsule will assume the raw data is in the [AIND
+ephys format](https://github.com/AllenNeuralDynamics/aind-physio-arch/blob/main/doc/file_formats/ephys.md). When JSON files are provided, the capsule will use this information 
+to load the raw and LFP data.
 
 ### Parameters
 
-The `code/run` script takes 2 arguments:
+The `code/run` script takes the following arguments:
 
 ```bash
-  --backend {hdf5,zarr}
-                        NWB backend. It can be either 'hdf5' or 'zarr'.
-  --asset-name ASSET_NAME
-                        Path to the data asset of the session. When provided, the metadata are fetched from the AIND metadata database. If None, and the attached data asset is used to fetch relevant metadata.
+  --stub                Write a stub version for testing
+  --stub-seconds STUB_SECONDS
+                        Duration of stub recording
+  --skip-lfp            Whether to write LFP electrical series
+  --write-raw           Whether to write RAW electrical series
+  --write-nidq          Whether to write NIDQ stream
+  --lfp_temporal_factor LFP_TEMPORAL_FACTOR
+                        Ratio of input samples to output samples in time. Use 0 or 1 to keep all samples. Default is 2.
+  --lfp_spatial_factor LFP_SPATIAL_FACTOR
+                        Controls number of channels to skip in spatial subsampling. Use 0 or 1 to keep all channels. Default is 4.
+  --lfp_highpass_freq_min LFP_HIGHPASS_FREQ_MIN
+                        Cutoff frequency for highpass filter to apply to the LFP recorsings. Default is 0.1 Hz. Use 0 to skip filtering.
+  --surface_channel_agar_probes_indices SURFACE_CHANNEL_AGAR_PROBES_INDICES
+                        Index of surface channel (e.g. index 0 corresponds to channel 1) of probe for common median referencing for probes in agar. Pass in as JSON
+                        string where key is probe and value is surface channel (e.g. "{'ProbeA': 350, 'ProbeB': 360}")
 ```
-
-The `--asset-name` input is only used at AIND to fetch metadata from the database.
-
 
 ### Output
 
-The output of this capsule is a NWB file in the `results/` folder named:
-`{session_name}.nwb`
-
-In case the `data/` folder contains a single NWB file, this is copied to the `results` with the same name.
+The output of this capsule is a set of NWB files in the `results/` folder named associated with different experiments/blocks and segments.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
-# aind-capsule-template
+# Export subject to NWB
+## NWB_Packaging_Subject_Capsule
 
-Basic structure of a capsule to be customized as needed.
+
+### Description
+
+This capsule is designed to append device, electrodes, and electrical series (raw and LFP) information to an existing NWB file.
+
+
+### Inputs
+
+The `data/` folder must include the session dataset and optionally the following JSON files:
+
+- `subject.json`: Subject information following the [aind-data-schema]() specification
+- `data_description.json`: session information following the [aind-data-schema]() specification
+
+The `data_description.json` is only used to access the `name` field, which is used as session name.
+An minimal example `data_description.json` file:
+
+```json
+{
+    "name": "my-awesome-session-name"
+}
+```
+
+If these files are missing, a mock NWB file is created.
+
+If the `data/` folder includes an NWB file, this is copied to the results folder.
+
+
+### Parameters
+
+The `code/run` script takes 2 arguments:
+
+```bash
+  --backend {hdf5,zarr}
+                        NWB backend. It can be either 'hdf5' or 'zarr'.
+  --asset-name ASSET_NAME
+                        Path to the data asset of the session. When provided, the metadata are fetched from the AIND metadata database. If None, and the attached data asset is used to fetch relevant metadata.
+```
+
+The `--asset-name` input is only used at AIND to fetch metadata from the database.
+
+
+### Output
+
+The output of this capsule is a NWB file in the `results/` folder named:
+`{session_name}.nwb`
+
+In case the `data/` folder contains a single NWB file, this is copied to the `results` with the same name.

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -44,7 +44,7 @@ data_folder = Path("../data/")
 scratch_folder = Path("../scratch/")
 results_folder = Path("../results/")
 
-job_kwargs = dict(n_jobs=-1, progress_bar=True)
+job_kwargs = dict(n_jobs=-1, progress_bar=False)
 si.set_global_job_kwargs(**job_kwargs)
 
 
@@ -527,7 +527,7 @@ if __name__ == "__main__":
 
                         # For NP2, save the LFP to speed up conversion later
                         if "AP" not in stream_name:
-                            recording_lfp = recording_lfp.save(folder=scratch_folder / f"{recording_folder_name}-LFP")
+                            recording_lfp = recording_lfp.save(folder=scratch_folder / f"{recording_name}-LFP")
 
                         print(f"\tAdding LFP data for stream {stream_name} - segment {segment_index}")
                         add_recording(

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -293,9 +293,13 @@ if __name__ == "__main__":
                             recording_job_dict = job_dict
                             break
                     if recording_job_dict is not None:
+                        print(f"Loading {recording_name} from JSON file")
                         recording = si.load_extractor(job_dict["recording_dict"], base_folder=data_folder)
+                        print(f"\t{recording}")
                         if "recording_lfp_dict" in job_dict:
+                            print(f"Loading LFP for {recording_name} from JSON file")
                             recording_lfp = si.load_extractor(job_dict["recording_lfp_dict"], base_folder=data_folder)
+                            print(f"\t{recording_lfp}")
                     else:
                         print(f"Could not find JSON file associated to {recording_name}. Loading recording from AIND raw data")
                         # Add Recordings

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -556,12 +556,16 @@ if __name__ == "__main__":
                 configure_backend(nwbfile=nwbfile, backend_configuration=backend_configuration)
 
                 print(f"Writing NWB file to {nwbfile_output_path}")
+                if NWB_BACKEND == "zarr":
+                    write_args = {'link_data': False}
+                else:
+                    write_args = {}
                 # if NWB_BACKEND == "zarr":
-                #     export_kwargs = {"number_of_jobs": n_jobs}
+                #    write_args = {"number_of_jobs": n_jobs}
                 # else:
-                #    export_kwargs = {}
+                #    write_args = {}
                 # TODO: enable parallel write
                 with io_class(str(nwbfile_output_path), "w") as export_io:
-                    export_io.export(src_io=read_io, nwbfile=nwbfile)
+                    export_io.export(src_io=read_io, nwbfile=nwbfile, write_args=write_args)
                 print(f"Done writing {nwbfile_output_path}")
                 nwb_output_files.append(nwbfile_output_path)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -17,13 +17,13 @@ from neuroconv.tools.nwb_helpers import (
 )
 from neuroconv.tools.spikeinterface import add_recording
 
-from pynwb import NWBHDF5IO, NWBFile
-from pynwb.file import Device, Subject
+from pynwb import NWBHDF5IO
+from pynwb.file import Device
 from hdmf_zarr import NWBZarrIO
 
 # for NWB Zarr, let's use built-in compressors, so thay can be read without Python
 from numcodecs import Blosc
-from utils import get_devices_from_metadata
+from utils import get_devices_from_rig_metadata
 
 # hdf5 or zarr
 STUB_TEST = False
@@ -31,8 +31,6 @@ STUB_SECONDS = 10
 WRITE_LFP = True
 WRITE_RAW = True
 WRITE_NIDQ = False
-
-DEBUG = True
 
 # filter and resample LFP
 lfp_filter_kwargs = dict(freq_min=0.1, freq_max=500)
@@ -69,8 +67,8 @@ write_lfp_group.add_argument("static_write_lfp", nargs="?", default="true", help
 
 write_raw_group = parser.add_mutually_exclusive_group()
 write_raw_help = "Whether to write RAW electrical series"
-write_raw_group.add_argument("--skip-raw", action="store_true", help=write_raw_help)
-write_raw_group.add_argument("static_write_raw", nargs="?", default="true", help=write_raw_help)
+write_raw_group.add_argument("--write-raw", action="store_true", help=write_raw_help)
+write_raw_group.add_argument("static_write_raw", nargs="?", default="false", help=write_raw_help)
 
 write_nidq_group = parser.add_mutually_exclusive_group()
 write_nidq_help = "Whether to write NIDQ stream"
@@ -123,10 +121,11 @@ if __name__ == "__main__":
     else:
         WRITE_LFP = True if args.static_write_lfp == "true" else False
 
-    if args.skip_raw:
+    if args.write_nidq:
         WRITE_RAW = False
     else:
         WRITE_RAW = True if args.static_write_raw == "true" else False
+
     if args.write_nidq:
         WRITE_NIDQ = True
     else:
@@ -157,16 +156,6 @@ if __name__ == "__main__":
     print(f"Highpass filter frequency: {HIGHPASS_FILTER_FREQ_MIN}")
     print(f"Surface channel indices for agar probes: {SURFACE_CHANNEL_AGAR_PROBES_INDICES}")
 
-    # find ecephys session
-    sessions = [
-        p.stem
-        for p in data_folder.iterdir()
-        if ("ecephys" in p.stem or "behavior" in p.stem) and "sorted" not in p.stem and "nwb" not in p.name
-    ]
-    assert len(sessions) == 1, "Attach one session (raw data) data at a time"
-    session = sessions[0]
-    ecephys_raw_folder = data_folder / session
-
     # find base NWB file
     nwb_files = [p for p in data_folder.iterdir() if p.name.endswith(".nwb") or p.name.endswith(".nwb.zarr")]
     assert len(nwb_files) == 1, "Attach one base NWB file data at a time"
@@ -175,42 +164,91 @@ if __name__ == "__main__":
     if nwbfile_input_path.is_dir():
         assert (nwbfile_input_path / ".zattrs").is_file(), f"{nwbfile_input_path.name} is not a valid Zarr folder"
         NWB_BACKEND = "zarr"
-        NWB_SUFFIX = ".nwb.zarr"
         io_class = NWBZarrIO
     else:
         NWB_BACKEND = "hdf5"
-        NWB_SUFFIX = ".nwb"
         io_class = NWBHDF5IO
     print(f"NWB backend: {NWB_BACKEND}")
 
-    print(f"\nExporting session: {session}")
-    session_folder = data_folder / session
-
-    if (data_folder / session / "ecephys_clipped").is_dir():
-        oe_folder = data_folder / session / "ecephys_clipped"
-        compressed_folder = data_folder / session / "ecephys_compressed"
-    else:
-        assert (data_folder / session / "ecephys").is_dir()
-        if (data_folder / session / "ecephys" / "ecephys_compressed").is_dir():
-            oe_folder = data_folder / session / "ecephys" / "ecephys_clipped"
-            compressed_folder = data_folder / session / "ecephys" / "ecephys_compressed"
-        else:
-            oe_folder = data_folder / session / "ecephys"
-            compressed_folder = None
-
-    # Read Open Ephys Folder structure with NEO
-    neo_io = OpenEphysBinaryRawIO(oe_folder)
-    neo_io.parse_header()
-    num_blocks = neo_io.block_count()
-    print(f"Number of experiments: {num_blocks}")
-    stream_names = neo_io.header["signal_streams"]["name"]
-    record_nodes = list(neo_io.folder_structure.keys())
-    experiment_ids = [eid for eid in neo_io.folder_structure[record_nodes[0]]["experiments"].keys()]
-    experiment_names = [e["name"] for eid, e in neo_io.folder_structure[record_nodes[0]]["experiments"].items()]
-    recording_names = [
-        r["name"]
-        for rid, r in neo_io.folder_structure[record_nodes[0]]["experiments"][experiment_ids[0]]["recordings"].items()
+    # find raw data
+    ecephys_folders = [
+        p
+        for p in data_folder.iterdir()
+        if p.is_dir()
+        and ("ecephys" in p.name or "behavior" in p.name)
+        and ("sorted" not in p.name and "nwb" not in p.name)
     ]
+    assert len(ecephys_folders) == 1, "Attach one ecephys folder at a time"
+    ecephys_folder = ecephys_folders[0]
+    session_name = ecephys_folder.name
+
+    print(f"\nExporting session: {session_name}")
+
+    job_json_files = [p for p in data_folder.iterdir() if p.suffix == ".json" and "job" in p.name]
+    job_dicts = []
+    for job_json_file in job_json_files:
+        with open(job_json_file) as f:
+            job_dict = json.load(f)
+        job_dicts.append(job_dict)
+    print(f"Found {len(job_dicts)} JSON job files")
+
+
+    if len(job_dicts) == 0:
+        print("Standalone mode!")
+        # AIND-specific section to parse AIND files
+        if (ecephys_folder / "ecephys_clipped").is_dir():
+            oe_folder = ecephys_folder / "ecephys_clipped"
+            compressed_folder = ecephys_folder / "ecephys_compressed"
+        else:
+            assert (ecephys_folder / "ecephys").is_dir()
+            if (ecephys_folder / "ecephys" / "ecephys_compressed").is_dir():
+                oe_folder = ecephys_folder / "ecephys" / "ecephys_clipped"
+                compressed_folder = ecephys_folder / "ecephys" / "ecephys_compressed"
+            else:
+                oe_folder = ecephys_folder / "ecephys"
+                compressed_folder = None
+
+        # Read Open Ephys Folder structure with NEO
+        neo_io = OpenEphysBinaryRawIO(oe_folder)
+        neo_io.parse_header()
+        num_blocks = neo_io.block_count()
+        print(f"Number of experiments: {num_blocks}")
+        stream_names = neo_io.header["signal_streams"]["name"]
+        record_nodes = list(neo_io.folder_structure.keys())
+        experiment_ids = [eid for eid in neo_io.folder_structure[record_nodes[0]]["experiments"].keys()]
+        experiment_names = [e["name"] for eid, e in neo_io.folder_structure[record_nodes[0]]["experiments"].items()]
+        recording_names = [
+            r["name"]
+            for rid, r in neo_io.folder_structure[record_nodes[0]]["experiments"][experiment_ids[0]]["recordings"].items()
+        ]
+        # in this case we don't need to split by group, since 
+        block_ids = experiment_names
+        recording_ids = recording_names
+    else:
+        # we create a result NWB file for each experiment/recording
+        recording_names = [job_dict["recording_name"] for job_dict in job_dicts]
+
+        # find blocks and recordings
+        block_ids = []
+        recording_ids = []
+        stream_names = []
+        for recording_name in recording_names:
+            if "group" in recording_name:
+                block_str = recording_name.split("_")[0]
+                recording_str = recording_name.split("_")[-2]
+                stream_name = "_".join(recording_name.split("_")[1:-2])
+            else:
+                block_str = recording_name.split("_")[0]
+                recording_str = recording_name.split("_")[-1]
+                stream_name = "_".join(recording_name.split("_")[1:-1])
+
+            if block_str not in block_ids:
+                block_ids.append(block_str)
+            if recording_str not in recording_ids:
+                recording_ids.append(recording_str)
+            if stream_name not in stream_names:
+                stream_names.append(stream_name)
+        # note: in case of groups, we will need to aggregate the data for each stream into a single recording
 
     streams_to_process = []
     for stream_name in stream_names:
@@ -223,60 +261,130 @@ if __name__ == "__main__":
         streams_to_process.append(stream_name)
     print(f"Number of streams to write: {len(streams_to_process)}")
 
-    if DEBUG:
-        streams_to_process = streams_to_process[:2]
-
     # Construct 1 nwb file per experiment - streams are concatenated!
     nwb_output_files = []
     electrical_series_to_configure = []
-    for block_index in range(num_blocks):
-        experiment_name = experiment_names[block_index]
-
-        num_segments = neo_io.segment_count(block_index)
-        for segment_index in range(num_segments):
+    nwb_output_files = []
+    for block_index, block_str in enumerate(block_ids):
+        for segment_index, recording_str in enumerate(recording_ids):
             recording_name = recording_names[segment_index]
 
-            nwbfile_out_name = f"{session}_{experiment_name}_experiment_name"
-
+            # add recording/experiment id if needed
+            nwb_original_file_name = nwbfile_input_path.stem
+            if block_str in nwb_original_file_name and recording_str in nwb_original_file_name:
+                nwb_file_name = nwb_original_file_name
+            else:
+                nwb_file_name = f"{nwb_original_file_name}_{block_str}_{recording_str}"
+            
             if STUB_TEST:
-                nwbfile_out_name = f"{nwbfile_out_name}_stub"
+                nwb_file_name = f"{nwb_file_name}_stub"
 
-            nwbfile_output_path = results_folder / f"{nwbfile_out_name}{NWB_SUFFIX}"
+            nwbfile_output_path = results_folder / f"{nwb_file_name}.nwb"
+
+            # Find probe devices (this will only work for AIND)
+            devices_from_rig, target_locations = get_devices_from_rig_metadata(
+                ecephys_folder, segment_index=segment_index
+            )
 
             # write 1 new nwb file per segment
             with io_class(str(nwbfile_input_path), "r") as read_io:
                 nwbfile = read_io.read()
 
                 for stream_name in streams_to_process:
-                    record_node, oe_stream_name = stream_name.split("#")
-                    recording_folder_name = f"{experiment_name}_{stream_name}_{recording_name}"
-                    settings_file = neo_io.folder_structure[record_node]["experiments"][experiment_ids[block_index]][
-                        "settings_file"
-                    ]
 
-                    # Add devices
-                    added_devices, target_locations = get_devices_from_metadata(
-                        session_folder, segment_index=segment_index
-                    )
-
-                    # if devices not found in metadata, instantiate using probeinterface
-                    if added_devices:
-                        for device_name, device in added_devices.items():
-                            if device_name not in nwbfile.devices:
-                                nwbfile.add_device(device)
-                        for device_name, targeted_location in target_locations.items():
-                            probe_no_spaces = device_name.replace(" ", "")
-                            if probe_no_spaces in oe_stream_name:
-                                probe_device_name = probe_no_spaces
-                                electrode_group_location = targeted_location
-                                print(f"Found device from rig: {probe_device_name}")
-                                break
+                    # load JSON and recordings
+                    recording_job_dict = None
+                    recording_lfp = None
+                    for job_dict in job_dicts:
+                        if job_dict["recording_name"] == recording_name:
+                            recording_job_dict = job_dict
+                            break
+                    if recording_job_dict is not None:
+                        recording = si.load_extractor(job_dict["recording_dict"], base_folder=data_folder)
+                        if "recording_lfp_dict" in job_dict:
+                            recording_lfp = si.load_extractor(job_dict["recording_lfp_dict"], base_folder=data_folder)
                     else:
-                        electrode_group_location = "unknown"
-                        probe = pi.read_openephys(settings_file, stream_name=oe_stream_name)
-                        probe_device_name = probe.name
-                        probe_device_description = f"Model: {probe.model_name} - Serial number: {probe.serial_number}"
-                        probe_device_manufacturer = f"{probe.manufacturer}"
+                        print(f"Could not find JSON file associated to {recording_name}. Loading recording from AIND raw data")
+                        # Add Recordings
+                        recording_multi_segment_lfp = None
+                        if compressed_folder is not None:
+                            stream_name_zarr = f"{block_str}_{stream_name}"
+                            recording_multi_segment = si.read_zarr(compressed_folder / f"{stream_name_zarr}.zarr")
+                            try:
+                                print(f"Trying to load LFP from {stream_name_zarr}")
+                                stream_name_zarr_lfp = stream_name_zarr.replace("AP", "LFP")
+                                recording_multi_segment_lfp = si.read_zarr(compressed_folder / f"{stream_name_zarr_lfp}.zarr")
+                            except:
+                                pass
+                        else:
+                            recording_multi_segment = se.read_openephys(
+                                oe_folder, stream_name=stream_name, block_index=block_index
+                            )
+                            try:
+                                recording_multi_segment_lfp = se.read_openephys(
+                                    oe_folder, stream_name=stream_name.replace("AP", "LFP"), block_index=block_index
+                                )
+                            except:
+                                pass
+                        recording = si.split_recording(recording_multi_segment)[segment_index]
+                        if recording_multi_segment_lfp is not None:
+                            recording_lfp = si.split_recording(recording_multi_segment_lfp)[segment_index]
+
+                    # Add device and electrode group
+                    probe_device_name = None
+                    if devices_from_rig:
+                        for device_name, device in devices_from_rig.items():
+                            # add the device, since it could be a laser
+                            if device_name not in nwbfile.devices:
+                                nwbfile.add_device(devices_from_rig[device_name])
+                            # find probe device name
+                            probe_no_spaces = device_name.replace(" ", "")
+                            if probe_no_spaces in stream_name:
+                                probe_device_name = probe_no_spaces
+                                electrode_group_location = target_locations.get(device_name, "unknown")
+                                print(
+                                    f"Found device from rig: {probe_device_name} at location {electrode_group_location}"
+                                )
+                                break
+                    probe_info = None
+                    if probe_device_name is None:
+                        if recording_job_dict is not None:
+                            electrode_group_location = "unknown"
+                            probes_info = recording.get_annotation("probes_info", None)
+                            if probes_info is not None and len(probes_info) == 1:
+                                probe_info = probes_info[0]
+                        else:
+                            electrode_group_location = "unknown"
+                            record_node, oe_stream_name = stream_name.split("#")
+                            recording_folder_name = f"{block_str}_{stream_name}_{recording_name}"
+                            settings_file = neo_io.folder_structure[record_node]["experiments"][experiment_ids[block_index]][
+                                "settings_file"
+                            ]
+                            probe = pi.read_openephys(settings_file, stream_name=oe_stream_name)
+                            probe_info = dict(
+                                name=probe.name,
+                                manuefacturer=probe.manufacturer,
+                                model_name=probe.model_name,
+                                serial_number=probe.serial_number,
+                            )
+                    
+                    if probe_info is not None:
+                        probe_device_name = probe_info.get("name", None)
+                        probe_device_manufacturer = probe_info.get("manufacturer", None)
+                        probe_model_name = probe_info.get("model_name", None)
+                        probe_serial_number = probe_info.get("serial_number", None)
+                        probe_device_description = ""
+                        if probe_device_name is None:
+                            if probe_model_name is not None:
+                                probe_device_name = probe_model_name
+                            else:
+                                probe_device_name = "Probe"
+                        if probe_model_name is not None:
+                            probe_device_description += f"Model: {probe_device_description}"
+                        if probe_serial_number is not None:
+                            if len(probe_device_description) > 0:
+                                probe_device_description += " - "
+                            probe_device_description += f"Serial number: {probe_serial_number}"
                         probe_device = Device(
                             name=probe_device_name,
                             description=probe_device_description,
@@ -284,18 +392,11 @@ if __name__ == "__main__":
                         )
                         if probe_device_name not in nwbfile.devices:
                             nwbfile.add_device(probe_device)
-                            print(f"\tAdded probe device: {probe_device.name} from probeinterface")
-
-                    # Add Recordings
-                    if compressed_folder is not None:
-                        stream_name_zarr = f"{experiment_name}_{stream_name}"
-                        recording_multi_segment = si.read_zarr(compressed_folder / f"{stream_name_zarr}.zarr")
+                            print(f"\tAdded probe device: {probe_device.name} from recording metadata")
                     else:
-                        recording_multi_segment = se.read_openephys(
-                            oe_folder, stream_name=stream_name, block_index=block_index
-                        )
-
-                    recording = si.split_recording(recording_multi_segment)[segment_index]
+                        print("\tCould not load device information: using default Device")
+                        probe_device_name = "Device"
+                        probe_device = Device(name=probe_device_name, description="Default device")
 
                     electrode_metadata = dict(
                         Ecephys=dict(
@@ -354,8 +455,8 @@ if __name__ == "__main__":
                             write_as="lfp",
                         )
 
-                        if "AP" not in stream_name:
-                            # Wide-band NP recording: filter and resample LFP
+                        if recording_lfp is None:
+                            # Wide-band recording: filter and resample LFP
                             print(
                                 f"\tAdding LFP data for stream {stream_name} from wide-band signal - segment {segment_index}"
                             )
@@ -382,25 +483,14 @@ if __name__ == "__main__":
                                 )
                                 recording_lfp.set_times(ts_lfp, segment_index=segment_index, with_warning=False)
                         else:
-                            # load LFP recording for NP1.0 probes
-                            lfp_stream_name = stream_name.replace("AP", "LFP")
-                            print(f"\tAdding LFP data for {lfp_stream_name} - segment {segment_index}")
-                            if compressed_folder is not None:
-                                stream_name_zarr = f"{experiment_name}_{lfp_stream_name}"
-                                recording_lfp = si.read_zarr(
-                                    ecephys_raw_folder / "ecephys_compressed" / f"{stream_name_zarr}.zarr"
-                                )
-                            else:
-                                recording_lfp = se.read_openephys(
-                                    oe_folder, stream_name=lfp_stream_name, block_index=block_index
-                                )
-
+                            print(f"\tAdding LFP data for {stream_name} from LFP stream - segment {segment_index}")
                         channel_ids = recording_lfp.get_channel_ids()
 
                         # re-reference only for agar - subtract median of channels out of brain using surface channel index arg
                         # similar processing to allensdk
                         if SURFACE_CHANNEL_AGAR_PROBES_INDICES is not None:
                             if probe.name in SURFACE_CHANNEL_AGAR_PROBES_INDICES:
+                                print(f"\t\tCommon median referencing for probe {probe.name}")
                                 surface_channel_index = SURFACE_CHANNEL_AGAR_PROBES_INDICES[probe.name]
                                 # get indices of channels out of brain including surface channel
                                 reference_channel_indices = np.arange(surface_channel_index, len(channel_ids))
@@ -414,15 +504,18 @@ if __name__ == "__main__":
 
                         # spatial subsampling from allensdk - keep every nth channel
                         if SPATIAL_CHANNEL_SUBSAMPLING_FACTOR > 1:
+                            print(f"\t\tSpatial subsampling factor: {SPATIAL_CHANNEL_SUBSAMPLING_FACTOR}")
                             channel_ids_to_keep = channel_ids[0 : len(channel_ids) : SPATIAL_CHANNEL_SUBSAMPLING_FACTOR]
                             recording_lfp = recording_lfp.channel_slice(channel_ids_to_keep)
 
                         # time subsampling/decimate
                         if TEMPORAL_SUBSAMPLING_FACTOR > 1:
+                            print(f"\t\tTemporal subsampling factor: {TEMPORAL_SUBSAMPLING_FACTOR}")
                             recording_lfp = spre.decimate(recording_lfp, TEMPORAL_SUBSAMPLING_FACTOR)
 
                         # high pass filter from allensdk
                         if HIGHPASS_FILTER_FREQ_MIN > 0:
+                            print(f"\t\tHighpass filter frequency: {HIGHPASS_FILTER_FREQ_MIN}")
                             recording_lfp = spre.highpass_filter(recording_lfp, freq_min=HIGHPASS_FILTER_FREQ_MIN)
 
                         # Assign to the correct channel group
@@ -436,6 +529,7 @@ if __name__ == "__main__":
                         if "AP" not in stream_name:
                             recording_lfp = recording_lfp.save(folder=scratch_folder / f"{recording_folder_name}-LFP")
 
+                        print(f"\tAdding LFP data for stream {stream_name} - segment {segment_index}")
                         add_recording(
                             recording=recording_lfp,
                             nwbfile=nwbfile,
@@ -449,14 +543,15 @@ if __name__ == "__main__":
 
                 print(f"Configuring {NWB_BACKEND} backend")
                 backend_configuration = get_default_backend_configuration(nwbfile=nwbfile, backend=NWB_BACKEND)
-                es_compressor = default_electrical_series_compressors[NWB_BACKEND]
+                # es_compressor = default_electrical_series_compressors[NWB_BACKEND]
 
-                for key in backend_configuration.dataset_configurations.keys():
-                    if any([es_name in key for es_name in electrical_series_to_configure]) and "timestamps" not in key:
-                        backend_configuration.dataset_configurations[key].compression_method = es_compressor
-                        print(f"\tSetting compression for {key} to {es_compressor}")
+                # for key in backend_configuration.dataset_configurations.keys():
+                #     if any([es_name in key for es_name in electrical_series_to_configure]) and "timestamps" not in key:
+                #         backend_configuration.dataset_configurations[key].compression_method = es_compressor
+                #         print(f"\tSetting compression for {key} to {es_compressor}")
                 configure_backend(nwbfile=nwbfile, backend_configuration=backend_configuration)
 
+                print(f"Writing NWB file to {nwbfile_output_path}")
                 with io_class(str(nwbfile_output_path), "w") as export_io:
                     export_io.export(src_io=read_io, nwbfile=nwbfile)
                 print(f"Done writing {nwbfile_output_path}")

--- a/code/utils.py
+++ b/code/utils.py
@@ -1,20 +1,20 @@
-
 import json
 import warnings
 from pathlib import Path
 from packaging.version import parse
 
+
 from pynwb.file import Device
 
 
-def get_devices_from_metadata(session_folder, segment_index=0):
+def get_devices_from_rig_metadata(session_folder: str, segment_index: int = 0):
     """
     Return NWB devices from metadata target locations.
 
     The schemas used to pupulate the NWBFile and metadata dictionaries are:
     - session.json
     - rig.json
-    
+
     Parameters
     ----------
     session_folder : str or Path
@@ -33,90 +33,147 @@ def get_devices_from_metadata(session_folder, segment_index=0):
     session_folder = Path(session_folder)
     session_file = session_folder / "session.json"
     rig_file = session_folder / "rig.json"
-    
+
     # load json files
     session = None
     if session_file.is_file():
         with open(session_file, "r") as f:
             session = json.load(f)
-    
+
     rig = None
     if rig_file.is_file():
         with open(rig_file, "r") as f:
             rig = json.load(f)
 
-    experimenter = None
     data_streams = None
-    session_start_time = None
     if session is not None:
-        if "schema_version" in session:
-            session_schema_version = session["schema_version"]
-            if parse(session_schema_version) >= parse("0.3.0"):
-                data_streams = session["data_streams"]
-            else:
-                warnings.warn(f"v{session_schema_version} for session schema is not currently supported")
+        session_schema_version = session.get("schema_version", None)
 
-    # Add devices here
-    added_devices = None
-    devices_target_location = {}
-    if rig is not None and data_streams is not None:
-        if "schema_version" in rig:
-            rig_schema_version = rig["schema_version"]
-            if parse(rig_schema_version) >= parse("0.5.1"):
-                if data_streams is not None:
-                    probe_devices = dict()
-                    probes_in_session = session["data_streams"][segment_index]["probes"]
-                    ephys_modules = rig["ephys_modules"]
+        if session_schema_version is None:
+            warnings.warn(f"Session file does not have schema_version")
+            return devices, devices_target_location
+        if parse(session_schema_version) >= parse("0.3.0"):
+            data_streams = session.get("data_streams", None)
+            if data_streams is None:
+                warnings.warn(f"Session file does not have data_streams")
+                return None, None
+        else:
+            warnings.warn(f"v{session_schema_version} for session schema is not currently supported")
+            return None, None
+    else:
+        warnings.warn(f"Session file not found in {session_folder}")
+        return None, None
 
-                    if len(probes_in_session) <= len(ephys_modules):
-                        for probe in probes_in_session:
-                            probe_name = probe["name"]
-                            for ephys_module in ephys_modules:
-                                probe_info = ephys_module["probes"][0]
-                                if probe_info["name"] == probe_name:
-                                    probe_device_name = probe_info['name']
-                                    probe_device_description = f"Model: {probe_info['probe_model']} - Serial number: {probe_info['serial_number']}"
-                                    probe_device_manufacturer = f"{probe_info['manufacturer']}"
-                                    probe_device = Device(name=probe_device_name, 
-                                                          description=probe_device_description,
-                                                          manufacturer=probe_device_manufacturer)
-                                    if added_devices is None:
-                                        added_devices = {}
-                                    added_devices[probe_device_name] = probe_device
-                                    devices_target_location[probe_device_name] = probe['primary_targeted_structure']
+    stimulus_epochs = session.get("stimulus_epochs", None)
+    if stimulus_epochs is not None:
+        stimulus_device_names = []
+        for epoch in stimulus_epochs:
+            stimulus_device_names += epoch.get("stimulus_device_names", [])
 
-                                    # Add internal lasers for NP-opto
-                                    if "lasers" in probe_info and len(probe_info["lasers"]) > 1:
-                                        for laser in probe_info["lasers"]:
-                                            laser_device_name = laser["name"]
-                                            laser_device_description = f"Type: internal - Wavelength: {laser['wavelength']}nm - Max power: {laser['maximum_power']}uW - Coupling: {laser['coupling']}"
-                                            laser_device_manufacturer = laser['manufacturer']
-                                            internal_laser_device = Device(name=laser_device_name,
-                                                                           description=laser_device_description,
-                                                                           manufacturer=laser_device_manufacturer)
-                                            if added_devices is None:
-                                                added_devices = {}
-                                            added_devices[laser_device_name] = internal_laser_device
+    if rig is not None:
+        rig_schema_version = rig.get("schema_version", None)
+        if rig_schema_version is None:
+            warnings.warn(f"Rig file does not have schema_version")
+            return None, None
+        if parse(rig_schema_version) >= parse("0.5.1"):
+            ephys_modules = session["data_streams"][segment_index]["ephys_modules"]
+            ephys_assemblies = rig.get("ephys_assemblies", [])
+            laser_assemblies = rig.get("laser_assemblies", [])
 
-                    # # TODO: Add external lasers should be added by other capsules
-                    # if "laser_modules" in rig:
-                    #     for laser in rig["laser_modules"][0]["lasers"]:
-                    #         laser_device_name = laser["name"]
-                    #         laser_device_description = f"Type: external - Wavelength: {laser['wavelength']}nm"
-                    #         if "coupling" in laser:
-                    #             laser_device_description += f" - Coupling: {laser['coupling']}"
-                    #         laser_device_manufacturer = laser['manufacturer'] # TODO get this info from rig.json
-                    #         external_laser_device = Device(name=laser_device_name,
-                    #                                        description=laser_device_description,
-                    #                                        manufacturer=laser_device_manufacturer)
-                    #       if added_devices is None:
-                    #           added_devices = {}
-                    #       added_devices[laser_device_name] = internal_laser_device
-                                
-                                                
-#                     else:
-#                         warnings.warn(f"Inconsistency between rig and session devices")
-            else:
-                warnings.warn(f"v{rig_schema_version} for rig schema is not currently supported")
+            # gather all probes and lasers
+            probe_devices = {}
+            laser_devices = {}
+            for ephys_assembly in ephys_assemblies:
+                probes_in_assembly = ephys_assembly["probes"]
 
-    return added_devices, devices_target_location
+                for probe_info in probes_in_assembly:
+                    probe_device_name = probe_info["name"]
+                    probe_model_name = probe_info.get("probe_model", None)
+                    probe_device_manufacturer = probe_info.get("manufacturer", None)
+                    probe_serial_number = probe_info.get("serial_number", None)
+                    probe_device_description = ""
+                    if probe_device_name is None:
+                        if probe_model_name is not None:
+                            probe_device_name = probe_model_name
+                        else:
+                            probe_device_name = "Probe"
+                    if probe_model_name is not None:
+                        probe_device_description += f"Model: {probe_device_description}"
+                    if probe_serial_number is not None:
+                        if len(probe_device_description) > 0:
+                            probe_device_description += " - "
+                        probe_device_description += f"Serial number: {probe_serial_number}"
+                    probe_device = Device(
+                        name=probe_device_name,
+                        description=probe_device_description,
+                        manufacturer=probe_device_manufacturer,
+                    )
+                    if probe_device_name not in probe_devices:
+                        probe_devices[probe_device_name] = probe_device
+                    # Add internal lasers for NP-opto
+                    if "lasers" in probe_info and len(probe_info["lasers"]) > 1:
+                        for laser in probe_info["lasers"]:
+                            laser_device_name = laser["name"]
+                            laser_device_description, laser_device_manufacturer = get_laser_description_manufacturer(
+                                laser, "internal"
+                            )
+                            internal_laser_device = Device(
+                                name=laser_device_name,
+                                description=laser_device_description,
+                                manufacturer=laser_device_manufacturer,
+                            )
+                            if laser_device_name not in laser_devices:
+                                laser_devices[laser_device_name] = internal_laser_device
+
+            for laser_assembly in laser_assemblies:
+                for laser in laser_assembly["lasers"]:
+                    laser_device_name = laser["name"]
+                    laser_device_description, laser_device_manufacturer = get_laser_description_manufacturer(
+                        laser, "external"
+                    )
+                    external_laser_device = Device(
+                        name=laser_device_name,
+                        description=laser_device_description,
+                        manufacturer=laser_device_manufacturer,
+                    )
+                    if laser_device_name not in laser_devices:
+                        laser_devices[laser_device_name] = external_laser_device
+
+            # get probes and lasers used in the session
+            devices = {}
+            devices_target_location = {}
+            for ephys_module in ephys_modules:
+                assembly_name = ephys_module["assembly_name"]
+
+                for probe_name, probe_device in probe_devices.items():
+                    if probe_name in assembly_name and probe_name not in devices:
+                        devices[probe_name] = probe_device
+                        devices_target_location[probe_name] = ephys_module["primary_targeted_structure"]
+            if len(stimulus_device_names) > 0:
+                for stimulus_device_name in stimulus_device_names:
+                    if stimulus_device_name in laser_devices and stimulus_device_name not in devices:
+                        devices[stimulus_device_name] = laser_devices[stimulus_device_name]
+        else:
+            warnings.warn(f"v{rig_schema_version} for rig schema is not currently supported")
+    else:
+        warnings.warn(f"Rig file not found in {session_folder}")
+
+    return devices, devices_target_location
+
+
+def get_laser_description_manufacturer(laser, type):
+    laser_device_description = f"Type: {type} "
+    wavelength = laser.get("wavelength", None)
+    if wavelength is not None:
+        laser_device_description += f" - Wavelength: {wavelength} {laser.get('wavelength_unit', 'nanometer')}"
+    max_power = laser.get("maximum_power", None)
+    if max_power is not None:
+        laser_device_description += f" - Max power: {max_power} {laser.get('power_unit', 'milliwatt')}"
+    coupling = laser.get("coupling", None)
+    if coupling is not None:
+        laser_device_description += f" - Coupling: {coupling}"
+    laser_device_manufacturer = laser.get("manufacturer", None)
+    if isinstance(laser_device_manufacturer, dict):
+        laser_device_manufacturer = laser_device_manufacturer.get("name", None)
+    return laser_device_description, laser_device_manufacturer
+

--- a/code/utils.py
+++ b/code/utils.py
@@ -176,4 +176,3 @@ def get_laser_description_manufacturer(laser, type):
     if isinstance(laser_device_manufacturer, dict):
         laser_device_manufacturer = laser_device_manufacturer.get("name", None)
     return laser_device_description, laser_device_manufacturer
-

--- a/metadata/metadata.yml
+++ b/metadata/metadata.yml
@@ -1,5 +1,5 @@
 metadata_version: 1
-name: NWB-Packaging-Ecephys-Capsule
+name: NWB-Packaging-Ecephys-Capsule (dispatch)
 description: Basic structure of a capsule to be customized as needed.
 authors:
 - name: AIND

--- a/metadata/metadata.yml
+++ b/metadata/metadata.yml
@@ -1,5 +1,5 @@
 metadata_version: 1
-name: NWB-Packaging-Neuropixels-Base-Capsule
+name: NWB-Packaging-Ecephys-Capsule
 description: Basic structure of a capsule to be customized as needed.
 authors:
 - name: AIND


### PR DESCRIPTION
This PR enables the Ecephys capsule to parse input data from SpikeInterface JSON files generated by the [aind-ephys-job-dispacth](https://github.com/AllenNeuralDynamics/aind-ephys-job-dispatch/) capsule. This allows also to save to NWB data coming from other acquisition formats (e.g., SpikeGLX, Open Ephys)

The default behavior of parsing ecephys data from the "aind" format in case of missing JSON files is preserved.